### PR TITLE
Fix ubuntu error

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -4,8 +4,8 @@
 	"Deps": [
 		{
 			"ImportPath": "github.com/STNS/STNS/attribute",
-			"Comment": "v0.0.1-45-g8d23181",
-			"Rev": "8d23181a70ad508ab126192177f85ecb622a7173"
+			"Comment": "v0.0.1-56-gddf0757",
+			"Rev": "ddf07572ee059179511babea80c1c7598242694a"
 		},
 		{
 			"ImportPath": "github.com/pyama86/toml",

--- a/package/RPM/SPECS/libnss_stns.spec
+++ b/package/RPM/SPECS/libnss_stns.spec
@@ -5,7 +5,7 @@ Name: libnss-stns
 Group: SipmleTomlNameService
 URL: https://github.com/pyama86/libnss_stns
 Version: 0.0
-Release: 1
+Release: 2
 License: MIT
 Source0:   libnss_stns.conf
 Packager:  libnss-stns
@@ -38,7 +38,7 @@ rm -rf %{buildroot}
 %config(noreplace) %{_sysconfdir}/stns/libnss_stns.conf
 
 %post
-ln -s /usr/%{_lib}/libnss_stns.so /usr/%{_lib}/libnss_stns.so.2
+ln -fs /usr/%{_lib}/libnss_stns.so /usr/%{_lib}/libnss_stns.so.2
 
 %postun
 rm -f /usr/%{_lib}/libnss_stns.so.2

--- a/package/deb/debian/changelog
+++ b/package/deb/debian/changelog
@@ -1,3 +1,9 @@
+libnss-stns (0.0.2) STABLE; urgency=low
+
+  * fix https://github.com/STNS/libnss_stns/pull/3
+
+ -- pyama86 <www.kazu.com@gmail.com>  Sat, 09 Jan 2016 10:43:05 +0000
+
 libnss-stns (0.0.1) UNSTABLE; urgency=low
 
   * Initial release. 

--- a/package/deb/debian/postinst
+++ b/package/deb/debian/postinst
@@ -6,7 +6,7 @@ DEB_HOST_MULTIARCH=`dpkg-architecture -qDEB_HOST_MULTIARCH`
 case "$1" in
 
   configure)
-    ln -s /usr/lib/$DEB_HOST_MULTIARCH/libnss_stns.so /lib/$DEB_HOST_MULTIARCH/libnss_stns.so.2
+    ln -sf /usr/lib/$DEB_HOST_MULTIARCH/libnss_stns.so /lib/$DEB_HOST_MULTIARCH/libnss_stns.so.2
   ;;
 
   abort-upgrade|abort-remove|abort-deconfigure|failed-upgrade)

--- a/request/request.go
+++ b/request/request.go
@@ -67,15 +67,7 @@ func (r *Request) Get() (attribute.UserGroups, error) {
 	// default negative cache
 	Cache[r.ApiPath] = &CacheObject{nil, errors.New(r.ApiPath + " is not fond")}
 
-	client := &http.Client{}
-
-	transport := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-	}
-
-	if r.Config.SslVerify == false {
-		client.Transport = transport
-	}
+	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: !r.Config.SslVerify}
 
 	for _, v := range perm {
 		endPoint := r.Config.ApiEndPoint[v]
@@ -85,7 +77,7 @@ func (r *Request) Get() (attribute.UserGroups, error) {
 			req.SetBasicAuth(r.Config.User, r.Config.Password)
 		}
 
-		res, err := client.Do(req)
+		res, err := http.DefaultClient.Do(req)
 
 		if err != nil {
 			lastError = err

--- a/resource.go
+++ b/resource.go
@@ -68,6 +68,7 @@ func setList(resource_type string, list attribute.UserGroups, position *int) {
 	resource, err := get(resource_type, "list", "")
 	if err != nil {
 		*position = NSS_STATUS_TRYAGAIN
+		return
 	}
 
 	if len(resource) > 0 {
@@ -75,7 +76,6 @@ func setList(resource_type string, list attribute.UserGroups, position *int) {
 			list[k] = v
 		}
 	}
-	return
 }
 
 func resetList(list attribute.UserGroups, position *int) {


### PR DESCRIPTION
```
 ls ~/panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x38 pc=0x7ff54c83f202]

goroutine 17 [running, locked to thread]:
net/http.(*Request).SetBasicAuth(0x0, 0xc82000af20, 0xc, 0xc82000afc0, 0xc)
        /usr/local/go/src/net/http/request.go:615 +0xa2
github.com/STNS/libnss_stns/request.(*Request).Get(0xc82000e580, 0x0, 0x0, 0x0)
        /go/src/github.com/STNS/libnss_stns/request/request.go:85 +0x67d
main.(*Resource).get(0xc820049e78, 0x7ff54ca6f2f8, 0x4, 0xc82000adb0, 0x2, 0x7ff54ce26020, 0x0, 0x0)
        /go/src/github.com/STNS/libnss_stns/resource.go:43 +0xb9
main.(*Resource).setResource(0xc820049e78, 0x7ff54b267558, 0xc82000ada0, 0x7ff54ca6f2f8, 0x4, 0xc82000adb0, 0x2, 0xc82006a040)
        /go/src/github.com/STNS/libnss_stns/resource.go:53 +0x55
main._nss_stns_getpwnam_r(0x22164b8, 0x7ff54d7b7060, 0x2094008, 0x400, 0x7ff54ddff690, 0x7ff54d7b7060)
        /go/src/github.com/STNS/libnss_stns/passwd.go:53 +0x121

goroutine 18 [syscall, locked to thread]:
runtime.goexit()
        /usr/local/go/src/runtime/asm_amd64.s:1721 +0x1
Connection to drone002.pepabo.com closed.
```
