### PR TITLE
key-wrapper: Add test for chained command and fix bug

### DIFF
--- a/cmd/key/stns-key-wrapper.go
+++ b/cmd/key/stns-key-wrapper.go
@@ -37,7 +37,7 @@ func Fetch(config *config.Config, name string) string {
 
 	if users != nil {
 		for _, u := range users {
-			userKeys += strings.Join(u.Keys, "\n")
+			userKeys += strings.Join(u.Keys, "\n") + "\n"
 		}
 		defer func() {
 			if err := recover(); err != nil {

--- a/cmd/key/test-fixtures/bin/get-external-keys
+++ b/cmd/key/test-fixtures/bin/get-external-keys
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if test "$#" -ne 1 || test -z "$1" ; then
+    echo "Invalid arguments for $0" >&2
+    exit 1
+fi
+
+echo 'external key1'
+echo 'external key2'


### PR DESCRIPTION
@pyama86 

Always terminate key list returned from stns-key-wrapper by a newline.
This ensures keys from STNS and chained command are separated by a NL.
