### PR TITLE
Respect proxy env on create http.Transport

### DIFF
--- a/libstns/request.go
+++ b/libstns/request.go
@@ -126,6 +126,7 @@ func (r *Request) httpDo(
 	f func(*http.Response, error),
 ) {
 	tr := &http.Transport{
+		Proxy:           http.ProxyFromEnvironment,
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: !r.Config.SslVerify},
 		Dial: (&net.Dialer{
 			Timeout:   time.Duration(r.Config.RequestTimeOut) * time.Second,


### PR DESCRIPTION
Current libnss-stns won't recognize http proxy env variables like `HTTP_PROXY`.

I have added extra `Proxy:` option just following DefaultTransport (https://golang.org/src/net/http/transport.go @ L33 ~). This WILL NOT change preceding behavior in packages.
