### PR TITLE
Support request header

### DIFF
--- a/libstns/config.go
+++ b/libstns/config.go
@@ -6,14 +6,15 @@ import (
 )
 
 type Config struct {
-	ApiEndPoint     []string `toml:"api_end_point"`
-	RequestTimeOut  int      `toml:"request_timeout"`
-	User            string   `toml:"user"`
-	Password        string   `toml:"password"`
-	SslVerify       bool     `toml:"ssl_verify"`
-	WrapperCommand  string   `toml:"wrapper_path"`
-	ChainSshWrapper string   `toml:"chain_ssh_wrapper"`
-	HttpProxy       string   `toml:"http_proxy"`
+	ApiEndPoint     []string          `toml:"api_end_point"`
+	RequestTimeOut  int               `toml:"request_timeout"`
+	User            string            `toml:"user"`
+	Password        string            `toml:"password"`
+	SslVerify       bool              `toml:"ssl_verify"`
+	WrapperCommand  string            `toml:"wrapper_path"`
+	ChainSshWrapper string            `toml:"chain_ssh_wrapper"`
+	HttpProxy       string            `toml:"http_proxy"`
+	RequestHeader   map[string]string `toml:"request_header"`
 }
 
 func LoadConfig(filePath string) (*Config, error) {

--- a/libstns/config_test.go
+++ b/libstns/config_test.go
@@ -1,28 +1,15 @@
 package libstns
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/STNS/libnss_stns/test"
 )
 
 func TestLoadConfig(t *testing.T) {
-
-	configFile, err := ioutil.TempFile("", "libnss_stns-config-test")
+	config, err := LoadConfig("./fixtures/config/test_config_001.conf")
 	test.AssertNoError(t, err)
-
-	configContent := "api_end_point=[\"is string\", \"is string\"]"
-
-	_, err = configFile.WriteString(configContent)
-	test.AssertNoError(t, err)
-
-	configFile.Close()
-	defer os.Remove(configFile.Name())
-
-	config, err := LoadConfig(configFile.Name())
-	test.AssertNoError(t, err)
-	test.Assert(t, config.ApiEndPoint[0] == "is string", "ng api endpoint")
-	test.Assert(t, config.ApiEndPoint[1] == "is string", "ng api endpoint")
+	test.Assert(t, config.ApiEndPoint[0] == "http://api01.example.com", "ng api endpoint1")
+	test.Assert(t, config.ApiEndPoint[1] == "http://api02.example.com", "ng api endpoint2")
+	test.Assert(t, config.RequestHeader["x-api-key"] == "fuga", "ng request header")
 }

--- a/libstns/fixtures/config/test_config_001.conf
+++ b/libstns/fixtures/config/test_config_001.conf
@@ -1,0 +1,4 @@
+api_end_point = ["http://api01.example.com","http://api02.example.com"]
+
+[request_header]
+x-api-key = "fuga"

--- a/libstns/request.go
+++ b/libstns/request.go
@@ -56,6 +56,11 @@ func (r *Request) GetRawData() ([]byte, error) {
 
 			u := strings.TrimRight(endPoint, "/") + "/" + strings.TrimLeft(r.ApiPath, "/")
 			req, err := http.NewRequest("GET", u, nil)
+
+			for k, v := range r.Config.RequestHeader {
+				req.Header.Add(k, v)
+			}
+
 			if err != nil {
 				ech <- err
 				return

--- a/libstns/request_test.go
+++ b/libstns/request_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/STNS/STNS/stns"
@@ -276,4 +277,24 @@ func checkResponse(t *testing.T, r *Request, apiVersion float64) {
 	if err == nil {
 		checkAttribute(t, res, apiVersion)
 	}
+}
+
+func TestRequestHeader(t *testing.T) {
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiKey := r.Header.Get("x-api-key")
+		if !strings.Contains(apiKey, "test") {
+			t.Errorf("unmatch header  error %s", apiKey)
+		}
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(handler))
+	defer server.Close()
+
+	c := &Config{}
+	c.ApiEndPoint = []string{server.URL}
+	c.RequestHeader = map[string]string{"x-api-key": "test"}
+
+	r, _ := NewRequest(c, "user", "name", "example")
+	r.GetRawData()
 }


### PR DESCRIPTION
awsなどをバックエンドにする際に、HTTPヘッダで認証する用途があるため実装しました。
ref:http://dev.classmethod.jp/cloud/apigateway-apikey-auth/
下記のように利用してください。

``` toml
[request_header]
x-api-key = "example key"
```
