### PR TITLE
move key wrapper

### DIFF
--- a/package/RPM/SPECS/libnss_stns.spec
+++ b/package/RPM/SPECS/libnss_stns.spec
@@ -1,4 +1,5 @@
 %define _localbindir /usr/local/bin
+%define _stnslibdir /usr/lib/stns
 %define _binaries_in_noarch_packages_terminate_build   0
 Summary: Simple Toml NameService Library
 Name: libnss-stns
@@ -24,14 +25,18 @@ SimpleTomlNameService Nss Module
 %install
 rm -rf %{buildroot}
 install -d -m 755 %{buildroot}/%{_localbindir}
-install    -m 655 %{_builddir}/stns-key-wrapper %{buildroot}/%{_localbindir}
-install    -m 655 %{_builddir}/stns-query-wrapper %{buildroot}/%{_localbindir}
+install    -m 755 %{_builddir}/stns-query-wrapper %{buildroot}/%{_localbindir}
+
+install -d -m 755 %{buildroot}/%{_stnslibdir}
+install    -m 755 %{_builddir}/stns-key-wrapper %{buildroot}/%{_stnslibdir}
+
+ln -fs %{_stnslibdir}/stns-key-wrapper %{buildroot}%{_localbindir}
 
 install -d -m 755 %{buildroot}/usr/%{_lib}
-install    -m 655 %{_builddir}/libnss_stns.so %{buildroot}/usr/%{_lib}
+install    -m 755 %{_builddir}/libnss_stns.so %{buildroot}/usr/%{_lib}
 
 install -d -m 755 %{buildroot}/%{_lib}/security
-install    -m 655 %{_builddir}/libpam_stns.so %{buildroot}/%{_lib}/security
+install    -m 755 %{_builddir}/libpam_stns.so %{buildroot}/%{_lib}/security
 
 install -d -m 755 %{buildroot}/%{_localstatedir}/log/
 
@@ -47,12 +52,14 @@ rm -rf %{buildroot}
 
 %files
 %defattr(-,root,root)
+%{_stnslibdir}/stns-key-wrapper
 %{_localbindir}/stns-key-wrapper
 %{_localbindir}/stns-query-wrapper
 /usr/%{_lib}/libnss_stns.so
 /usr/%{_lib}/libnss_stns.so.2
 %config(noreplace) %{_sysconfdir}/stns/libnss_stns.conf
 
+%dir %attr(0700, root, root) %{_stnslibdir}
 %dir /var/lib/libnss_stns
 
 %files -n libpam-stns

--- a/package/deb/debian/libnss-stns.links.in
+++ b/package/deb/debian/libnss-stns.links.in
@@ -1,1 +1,2 @@
 /usr/lib/@DEB_HOST_MULTIARCH@/libnss_stns.so /lib/@DEB_HOST_MULTIARCH@/libnss_stns.so.2
+/usr/lib/stns/stns-key-wrapper /usr/local/bin/stns-key-wrapper

--- a/package/deb/debian/libnss-stns.postinst
+++ b/package/deb/debian/libnss-stns.postinst
@@ -3,3 +3,4 @@ set -e
 
 mkdir -p /var/lib/libnss_stns
 chmod 777 /var/lib/libnss_stns
+chmod 700 /usr/lib/stns

--- a/package/deb/debian/rules
+++ b/package/deb/debian/rules
@@ -18,8 +18,9 @@ override_dh_auto_configure:
 override_dh_auto_install:
 	dh_auto_install
 	install -d -m 755 debian/${package}/usr/local/bin/
-	install    -m 655 debian/stns-query-wrapper debian/${package}/usr/local/bin/stns-query-wrapper
-	install    -m 655 debian/stns-key-wrapper debian/${package}/usr/local/bin/stns-key-wrapper
+	install    -m 755 debian/stns-query-wrapper debian/${package}/usr/local/bin/stns-query-wrapper
+	install -d -m 700 debian/${package}/usr/lib/stns/
+	install    -m 755 debian/stns-key-wrapper debian/${package}/usr/lib/stns/stns-key-wrapper
 	install -d -m 755 debian/${package}/usr/lib/$(DEB_HOST_MULTIARCH)/
 	install -d -m 755 debian/${package}/etc/stns/
 	install    -m 644 debian/libnss_stns.conf debian/${package}/etc/stns/libnss_stns.conf

--- a/spec/localhost/install_spec.rb
+++ b/spec/localhost/install_spec.rb
@@ -6,6 +6,25 @@ describe file("/etc/stns/libnss_stns.conf") do
   it { should be_grouped_into('root') }
 end
 
+describe file("/usr/lib/stns") do
+  it { should be_directory }
+  it { should be_mode(700) }
+  it { should be_owned_by('root') }
+  it { should be_grouped_into('root') }
+end
+
+describe file("/usr/lib/stns/stns-key-wrapper") do
+  it { should be_mode(755) }
+  it { should be_owned_by('root') }
+  it { should be_grouped_into('root') }
+end
+
+describe file("/usr/local/bin/stns-key-wrapper") do
+  it { should be_symlink }
+  it { should be_owned_by('root') }
+  it { should be_grouped_into('root') }
+end
+
 files = if os[:family] == 'redhat'
   if i386?
     %w(


### PR DESCRIPTION
stns-key-wrapperがdebianで怒られるようなので、配置場所を変更します。
