### PR TITLE
check the network before you run the query

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,7 +1,7 @@
 {
 	"ImportPath": "github.com/STNS/libnss_stns",
 	"GoVersion": "go1.6",
-	"GodepVersion": "v66",
+	"GodepVersion": "v74",
 	"Packages": [
 		"./..."
 	],
@@ -13,13 +13,13 @@
 		},
 		{
 			"ImportPath": "github.com/STNS/STNS/settings",
-			"Comment": "v0.1-3-6-g9ef4bef",
-			"Rev": "9ef4bef00a31a183fb9e8f5b6a5c0ae4303baf70"
+			"Comment": "v0.2-0-3-gd173b63",
+			"Rev": "d173b63f30a6ee339b97a717d2fccdad94e84cae"
 		},
 		{
 			"ImportPath": "github.com/STNS/STNS/stns",
-			"Comment": "v0.1-3-6-g9ef4bef",
-			"Rev": "9ef4bef00a31a183fb9e8f5b6a5c0ae4303baf70"
+			"Comment": "v0.2-0-3-gd173b63",
+			"Rev": "d173b63f30a6ee339b97a717d2fccdad94e84cae"
 		},
 		{
 			"ImportPath": "github.com/ant0ine/go-json-rest/rest",

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -13,13 +13,13 @@
 		},
 		{
 			"ImportPath": "github.com/STNS/STNS/settings",
-			"Comment": "v0.2-0-3-gd173b63",
-			"Rev": "d173b63f30a6ee339b97a717d2fccdad94e84cae"
+			"Comment": "v0.2-1-2-gb13fce6",
+			"Rev": "b13fce62ae4afc33250b36a2e3abd99db23615db"
 		},
 		{
 			"ImportPath": "github.com/STNS/STNS/stns",
-			"Comment": "v0.2-0-3-gd173b63",
-			"Rev": "d173b63f30a6ee339b97a717d2fccdad94e84cae"
+			"Comment": "v0.2-1-2-gb13fce6",
+			"Rev": "b13fce62ae4afc33250b36a2e3abd99db23615db"
 		},
 		{
 			"ImportPath": "github.com/ant0ine/go-json-rest/rest",

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -80,15 +80,19 @@ func SaveResultList(resourceType string, list stns.Attributes) {
 
 func LastResultList(resourceType string) *stns.Attributes {
 	var attr stns.Attributes
-	f, err := ioutil.ReadFile(workDir + "/.libnss_stns_" + resourceType + "_cache")
-	if err != nil {
-		log.Println(err)
-		return &attr
-	}
+	f := workDir + "/.libnss_stns_" + resourceType + "_cache"
 
-	err = json.Unmarshal(f, &attr)
-	if err != nil {
-		log.Println(err)
+	if _, err := os.Stat(f); err == nil {
+		f, err := ioutil.ReadFile(f)
+		if err != nil {
+			log.Println(err)
+			return &attr
+		}
+
+		err = json.Unmarshal(f, &attr)
+		if err != nil {
+			log.Println(err)
+		}
 	}
 	return &attr
 }

--- a/cmd/key/stns-key-wrapper.go
+++ b/cmd/key/stns-key-wrapper.go
@@ -47,7 +47,7 @@ func Fetch(config *libstns.Config, name string) string {
 	}
 
 	if res.Items != nil {
-		for _, u := range *res.Items {
+		for _, u := range res.Items {
 			if len(u.Keys) > 0 {
 				userKeys += strings.Join(u.Keys, "\n") + "\n"
 			}

--- a/libstns/nss.go
+++ b/libstns/nss.go
@@ -72,8 +72,8 @@ func (n *Nss) Get(column, value string) (stns.Attributes, error) {
 		return nil, ne
 	}
 
-	cache.Write(req.ApiPath, *res.Items, nil)
-	return *res.Items, nil
+	cache.Write(req.ApiPath, res.Items, nil)
+	return res.Items, nil
 }
 
 func (n *Nss) Set(s NssEntry, column, value string) int {

--- a/libstns/pam.go
+++ b/libstns/pam.go
@@ -65,7 +65,7 @@ func (p *Pam) PasswordAuth(user string, password string) int {
 	}
 
 	var attr stns.Attribute
-	for _, a := range *res.Items {
+	for _, a := range res.Items {
 		attr = *a
 		break
 	}

--- a/libstns/request.go
+++ b/libstns/request.go
@@ -174,7 +174,7 @@ func (r *Request) migrateV2Format(body []byte) ([]byte, error) {
 			stns_settings.SUCCESS,
 			0,
 		},
-		&attr,
+		attr,
 	}
 
 	j, err := json.Marshal(mig)

--- a/libstns/request_test.go
+++ b/libstns/request_test.go
@@ -233,7 +233,7 @@ func checkAttribute(t *testing.T, res stns.ResponseFormat, apiVersion float64) {
 		}
 	}
 
-	for n, u := range *res.Items {
+	for n, u := range res.Items {
 		if n != "example" {
 			t.Error("unmatch name")
 		}
@@ -263,7 +263,7 @@ func checkResponse(t *testing.T, r *Request, apiVersion float64) {
 	var res stns.ResponseFormat
 	raw, err := r.GetRawData()
 	json.Unmarshal(raw, &res)
-	if err != nil || res.Items == nil || 0 == len(*res.Items) {
+	if err != nil || res.Items == nil || 0 == len(res.Items) {
 		t.Errorf("fetch error %s", err)
 	}
 	if err == nil {

--- a/libstns/utils.go
+++ b/libstns/utils.go
@@ -1,0 +1,18 @@
+package libstns
+
+import "net"
+
+func NicReady() bool {
+	is, err := net.Interfaces()
+	if err != nil {
+		return false
+	}
+
+	for _, i := range is {
+		if i.Name[0:2] == "lo" || i.Flags&(1<<uint(0)) == 0 {
+			continue
+		}
+		return true
+	}
+	return false
+}

--- a/nss/main.go
+++ b/nss/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"log"
+
 	"github.com/STNS/STNS/stns"
 	"github.com/STNS/libnss_stns/libstns"
 )
@@ -23,6 +25,12 @@ var spwdReadPos int
 
 func init() {
 	libstns.Setlog()
+
+	if !libstns.NicReady() {
+		log.Println("does not have a valid network interface")
+		return
+	}
+
 	config, err := libstns.LoadConfig("/etc/stns/libnss_stns.conf")
 	if err != nil {
 		return

--- a/package/deb/debian/control
+++ b/package/deb/debian/control
@@ -9,7 +9,7 @@ Homepage: https://github.com/pyama86/libnss_stns
 Package: libnss-stns
 Architecture: any
 Description: simple toml name service nss module
-Depends: dpkg-dev
+Depends: ${misc:Depends}
 Pre-Depends: ${misc:Pre-Depends}
 
 Package: libpam-stns

--- a/pam/main.go
+++ b/pam/main.go
@@ -22,6 +22,11 @@ func init() {
 
 //export pam_sm_authenticate
 func pam_sm_authenticate(pamh *C.pam_handle_t, flags C.int, argc C.int, argv **C.char) C.int {
+	if !libstns.NicReady() {
+		log.Println("does not have a valid network interface")
+		return C.PAM_AUTHINFO_UNAVAIL
+	}
+
 	config, err := libstns.LoadConfig("/etc/stns/libnss_stns.conf")
 	if err != nil {
 		log.Println(err)


### PR DESCRIPTION
libnss-stns happen trouble ubuntu 14.04 in os startup.
may be the cause is this.

```
[    2.533771] EXT4-fs (sda1): INFO: recovery required on readonly filesystem
```
1. os startup
2.  stns-query exec → network has not been started
3. create lock file → recovery required on readonly filesystem
4. becomes strange

this pr added check method before `stns-query exec`.
