### PR TITLE
add parameter uid gid shift

### DIFF
--- a/libstns/config.go
+++ b/libstns/config.go
@@ -19,6 +19,8 @@ type Config struct {
 	TlsCa           string            `toml:"tls_ca"`
 	TlsCert         string            `toml:"tls_cert"`
 	TlsKey          string            `toml:"tls_key"`
+	UIDShift        int               `toml:"uid_shift"`
+	GIDShift        int               `toml:"gid_shift"`
 }
 
 func LoadConfig(filePath string) (*Config, error) {
@@ -37,4 +39,6 @@ func defaultConfig(config *Config) {
 	config.RequestRetry = 1
 	config.WrapperCommand = "/usr/local/bin/stns-query-wrapper"
 	config.ApiEndPoint = []string{"http://localhost:1104"}
+	config.UIDShift = 0
+	config.GIDShift = 0
 }

--- a/libstns/config_test.go
+++ b/libstns/config_test.go
@@ -16,4 +16,6 @@ func TestLoadConfig(t *testing.T) {
 	test.Assert(t, config.TlsCert == "tls.crt", "unmatch tls crt")
 	test.Assert(t, config.TlsKey == "tls.key", "unmatch tls key")
 	test.Assert(t, config.RequestRetry == 3, "ng request retry")
+	test.Assert(t, config.UIDShift == -1000, "unmatch uid shift")
+	test.Assert(t, config.GIDShift == -2000, "unmatch gid shift")
 }

--- a/libstns/fixtures/config/test_config_001.conf
+++ b/libstns/fixtures/config/test_config_001.conf
@@ -4,6 +4,8 @@ retry_request = 3
 tls_ca = "ca.pem"
 tls_cert = "tls.crt"
 tls_key = "tls.key"
+uid_shift = -1000
+gid_shift = -2000
 
 [request_header]
 x-api-key = "fuga"

--- a/libstns/response_parser.go
+++ b/libstns/response_parser.go
@@ -58,37 +58,47 @@ func convertV3Format(b []byte, path string, minID string, config *Config) (*Resp
 			}
 			for _, u := range users {
 				if u.Name != "" && u.ID+config.UIDShift > settings.MIN_LIMIT_ID {
+					tmpUser := &stns.User{
+						Password:  u.Password,
+						Directory: u.Directory,
+						Shell:     u.Shell,
+						Gecos:     u.Gecos,
+						Keys:      u.Keys,
+					}
+
+					if u.GroupID+config.GIDShift > settings.MIN_LIMIT_ID {
+						tmpUser.GroupID = u.GroupID + config.GIDShift
+					}
+
 					attr[u.Name] = &stns.Attribute{
-						ID: u.ID + config.UIDShift,
-						User: &stns.User{
-							Password:  u.Password,
-							GroupID:   u.GroupID + config.GIDShift,
-							Directory: u.Directory,
-							Shell:     u.Shell,
-							Gecos:     u.Gecos,
-							Keys:      u.Keys,
-						},
+						ID:   u.ID + config.UIDShift,
+						User: tmpUser,
 					}
 				}
 			}
 		} else {
-			user := v3User{}
-			err = json.Unmarshal(b, &user)
+			u := v3User{}
+			err = json.Unmarshal(b, &u)
 			if err != nil {
 				return nil, err
 			}
 
-			if user.Name != "" && user.ID+config.UIDShift > settings.MIN_LIMIT_ID {
-				attr[user.Name] = &stns.Attribute{
-					ID: user.ID + config.UIDShift,
-					User: &stns.User{
-						Password:  user.Password,
-						GroupID:   user.GroupID + config.GIDShift,
-						Directory: user.Directory,
-						Shell:     user.Shell,
-						Gecos:     user.Gecos,
-						Keys:      user.Keys,
-					},
+			if u.Name != "" && u.ID+config.UIDShift > settings.MIN_LIMIT_ID {
+				tmpUser := &stns.User{
+					Password:  u.Password,
+					Directory: u.Directory,
+					Shell:     u.Shell,
+					Gecos:     u.Gecos,
+					Keys:      u.Keys,
+				}
+
+				if u.GroupID+config.GIDShift > settings.MIN_LIMIT_ID {
+					tmpUser.GroupID = u.GroupID + config.GIDShift
+				}
+
+				attr[u.Name] = &stns.Attribute{
+					ID:   u.ID + config.UIDShift,
+					User: tmpUser,
 				}
 			}
 		}
@@ -110,33 +120,33 @@ func convertV3Format(b []byte, path string, minID string, config *Config) (*Resp
 				}
 			}
 		} else {
-			group := v3Group{}
-			err = json.Unmarshal(b, &group)
+			g := v3Group{}
+			err = json.Unmarshal(b, &g)
 			if err != nil {
 				return nil, err
 			}
 
-			if group.ID+config.GIDShift > settings.MIN_LIMIT_ID {
-				attr[group.Name] = &stns.Attribute{
-					ID: group.ID + config.GIDShift,
+			if g.ID+config.GIDShift > settings.MIN_LIMIT_ID {
+				attr[g.Name] = &stns.Attribute{
+					ID: g.ID + config.GIDShift,
 					Group: &stns.Group{
-						Users: group.Users,
+						Users: g.Users,
 					},
 				}
 			}
 		}
 	case "sudo":
-		user := v3Sudo{}
-		err = json.Unmarshal(b, &user)
+		u := v3Sudo{}
+		err = json.Unmarshal(b, &u)
 		if err != nil {
 			return nil, err
 		}
 
-		if user.Name != "" && user.Password != "" {
-			attr[user.Name] = &stns.Attribute{
+		if u.Name != "" && u.Password != "" {
+			attr[u.Name] = &stns.Attribute{
 				ID: 0,
 				User: &stns.User{
-					Password: user.Password,
+					Password: u.Password,
 				},
 			}
 		}

--- a/libstns/response_parser.go
+++ b/libstns/response_parser.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/STNS/STNS/stns"
+	"github.com/STNS/libnss_stns/settings"
 )
 
 func convertV1toV3Format(body []byte) (*ResponseFormat, error) {
@@ -56,7 +57,7 @@ func convertV3Format(b []byte, path string, minID string, config *Config) (*Resp
 				return nil, err
 			}
 			for _, u := range users {
-				if u.Name != "" && u.ID != 0 {
+				if u.Name != "" && u.ID+config.UIDShift > settings.MIN_LIMIT_ID {
 					attr[u.Name] = &stns.Attribute{
 						ID: u.ID + config.UIDShift,
 						User: &stns.User{
@@ -77,7 +78,7 @@ func convertV3Format(b []byte, path string, minID string, config *Config) (*Resp
 				return nil, err
 			}
 
-			if user.Name != "" && user.ID != 0 {
+			if user.Name != "" && user.ID+config.UIDShift > settings.MIN_LIMIT_ID {
 				attr[user.Name] = &stns.Attribute{
 					ID: user.ID + config.UIDShift,
 					User: &stns.User{
@@ -99,7 +100,7 @@ func convertV3Format(b []byte, path string, minID string, config *Config) (*Resp
 				return nil, err
 			}
 			for _, g := range groups {
-				if g.ID != 0 {
+				if g.ID+config.GIDShift > settings.MIN_LIMIT_ID {
 					attr[g.Name] = &stns.Attribute{
 						ID: g.ID + config.GIDShift,
 						Group: &stns.Group{
@@ -115,7 +116,7 @@ func convertV3Format(b []byte, path string, minID string, config *Config) (*Resp
 				return nil, err
 			}
 
-			if group.ID != 0 {
+			if group.ID+config.GIDShift > settings.MIN_LIMIT_ID {
 				attr[group.Name] = &stns.Attribute{
 					ID: group.ID + config.GIDShift,
 					Group: &stns.Group{

--- a/libstns/response_parser_test.go
+++ b/libstns/response_parser_test.go
@@ -1,0 +1,177 @@
+package libstns
+
+import (
+	"testing"
+
+	"github.com/STNS/libnss_stns/test"
+)
+
+// UID,GIDのシフトをテストする
+// 通常のレスポンステストはRequestにて包括的にテストしている
+func TestUserConvertV3Format(t *testing.T) {
+	c := &Config{}
+	r, err := convertV3Format([]byte(test.GetV3UserExample()), "/user/name/example", "1000", c)
+	if err != nil {
+		t.Errorf("not assume an error but got %s", err)
+	}
+
+	for n, u := range r.Items {
+		if n != "example" {
+			t.Error("unmatch name")
+		}
+
+		if u.ID != 2000 {
+			t.Error("unmatch id")
+		}
+
+		if u.GroupID != 3000 {
+			t.Error("unmatch group")
+		}
+	}
+
+	c = &Config{
+		UIDShift: -1000,
+		GIDShift: -2000,
+	}
+
+	r, err = convertV3Format([]byte(test.GetV3UserExample()), "/user/name/example", "1000", c)
+	if err != nil {
+		t.Errorf("not assume an error but got %s", err)
+	}
+
+	for n, u := range r.Items {
+		if n != "example" {
+			t.Error("unmatch name")
+		}
+
+		if u.ID != 1000 {
+			t.Error("unmatch id")
+		}
+
+		if u.GroupID != 1000 {
+			t.Error("unmatch group")
+		}
+	}
+}
+
+func TestUsersConvertV3Format(t *testing.T) {
+	c := &Config{}
+	r, err := convertV3Format([]byte(test.GetV3UsersExample()), "/user/list", "1000", c)
+	if err != nil {
+		t.Errorf("not assume an error but got %s", err)
+	}
+
+	for n, u := range r.Items {
+		if n != "example" {
+			t.Error("unmatch name")
+		}
+
+		if u.ID != 2000 {
+			t.Error("unmatch id")
+		}
+
+		if u.GroupID != 3000 {
+			t.Error("unmatch group")
+		}
+	}
+
+	c = &Config{
+		UIDShift: -1000,
+		GIDShift: -2000,
+	}
+
+	r, err = convertV3Format([]byte(test.GetV3UsersExample()), "/user/list", "1000", c)
+	if err != nil {
+		t.Errorf("not assume an error but got %s", err)
+	}
+
+	for n, u := range r.Items {
+		if n != "example" {
+			t.Error("unmatch name")
+		}
+
+		if u.ID != 1000 {
+			t.Error("unmatch id")
+		}
+
+		if u.GroupID != 1000 {
+			t.Error("unmatch group")
+		}
+	}
+}
+
+func TestGroupConvertV3Format(t *testing.T) {
+	c := &Config{}
+	r, err := convertV3Format([]byte(test.GetV3GroupExample()), "/group/name/example", "1000", c)
+	if err != nil {
+		t.Errorf("not assume an error but got %s", err)
+	}
+
+	for n, u := range r.Items {
+		if n != "example" {
+			t.Error("unmatch name")
+		}
+
+		if u.ID != 2000 {
+			t.Error("unmatch id")
+		}
+	}
+
+	c = &Config{
+		UIDShift: -1000,
+		GIDShift: -1000,
+	}
+
+	r, err = convertV3Format([]byte(test.GetV3GroupExample()), "/group/name/example", "1000", c)
+	if err != nil {
+		t.Errorf("not assume an error but got %s", err)
+	}
+
+	for n, u := range r.Items {
+		if n != "example" {
+			t.Error("unmatch name")
+		}
+
+		if u.ID != 1000 {
+			t.Error("unmatch id")
+		}
+	}
+}
+
+func TestGroupsConvertV3Format(t *testing.T) {
+	c := &Config{}
+	r, err := convertV3Format([]byte(test.GetV3GroupsExample()), "/group/list", "1000", c)
+	if err != nil {
+		t.Errorf("not assume an error but got %s", err)
+	}
+
+	for n, u := range r.Items {
+		if n != "example" {
+			t.Error("unmatch name")
+		}
+
+		if u.ID != 2000 {
+			t.Error("unmatch id")
+		}
+	}
+
+	c = &Config{
+		UIDShift: -1000,
+		GIDShift: -1000,
+	}
+
+	r, err = convertV3Format([]byte(test.GetV3GroupsExample()), "/group/list", "1000", c)
+	if err != nil {
+		t.Errorf("not assume an error but got %s", err)
+	}
+
+	for n, u := range r.Items {
+		if n != "example" {
+			t.Error("unmatch name")
+		}
+
+		if u.ID != 1000 {
+			t.Error("unmatch id")
+		}
+	}
+}

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -6,6 +6,7 @@ const (
 	LOCK_TIME    = 10
 	LOCK_FILE    = "/tmp/.libstns_lock"
 	WORK_DIR     = "/var/lib/libnss_stns"
+	MIN_LIMIT_ID = 100
 )
 
 const (


### PR DESCRIPTION
uidやgidをシフトするパラメーターを追加します。

```toml
 uid_shift = -1000
 gid_shift = -2000
```

このように定義するとサーバに定義された`uid:3000`はクライアントでは`uid:2000`として処理されるようになります。