### PR TITLE
not foundはerr出力する

### DIFF
--- a/cmd/key/stns-key-wrapper.go
+++ b/cmd/key/stns-key-wrapper.go
@@ -43,19 +43,19 @@ func Fetch(config *libstns.Config, name string) string {
 		if err != nil {
 			log.Println(err)
 		}
-	}
 
-	if res.Items != nil {
-		for _, u := range res.Items {
-			if len(u.Keys) > 0 {
-				userKeys += strings.Join(u.Keys, "\n") + "\n"
+		if res.Items != nil {
+			for _, u := range res.Items {
+				if len(u.Keys) > 0 {
+					userKeys += strings.Join(u.Keys, "\n") + "\n"
+				}
 			}
+			defer func() {
+				if err := recover(); err != nil {
+					log.Print(err)
+				}
+			}()
 		}
-		defer func() {
-			if err := recover(); err != nil {
-				log.Print(err)
-			}
-		}()
 	}
 
 	rex := regexp.MustCompile(`stns-key-wrapper$`)

--- a/libstns/request_test.go
+++ b/libstns/request_test.go
@@ -155,8 +155,8 @@ func TestRequestV2NotFound(t *testing.T) {
 	var res ResponseFormat
 	raw, err := r.GetRawData()
 	json.Unmarshal(raw, &res)
-	if err != nil {
-		t.Errorf("fetch error %s", err)
+	if err == nil {
+		t.Errorf("fetch error expect not found")
 	}
 }
 
@@ -172,8 +172,8 @@ func TestRequestV3NotFound(t *testing.T) {
 	var res ResponseFormat
 	raw, err := r.GetRawData()
 	json.Unmarshal(raw, &res)
-	if err != nil {
-		t.Errorf("fetch error %s", err)
+	if err == nil {
+		t.Errorf("fetch error expect not found")
 	}
 }
 


### PR DESCRIPTION
これまでは出力の多さを懸念して、抑制していましたが、resource not foundはエラーとして出力するようにしました。