### PR TITLE
the client backward compatible

### DIFF
--- a/libstns/request.go
+++ b/libstns/request.go
@@ -29,7 +29,7 @@ type Request struct {
 }
 
 func NewRequest(config *Config, paths ...string) (*Request, error) {
-	if len(paths) == 3 {
+	if len(paths) == 3 && strings.Contains(paths[2], ".") {
 		paths[2] = urlencode(paths[2])
 	}
 


### PR DESCRIPTION
If api side is not up to date, it does not work well, so backward compatibility is set up