### PR TITLE
request retry 3 times on default

### DIFF
--- a/libstns/config.go
+++ b/libstns/config.go
@@ -36,7 +36,7 @@ func LoadConfig(filePath string) (*Config, error) {
 
 func defaultConfig(config *Config) {
 	config.RequestTimeOut = settings.HTTP_TIMEOUT
-	config.RequestRetry = 1
+	config.RequestRetry = 3
 	config.WrapperCommand = "/usr/local/bin/stns-query-wrapper"
 	config.ApiEndPoint = []string{"http://localhost:1104"}
 	config.UIDShift = 0


### PR DESCRIPTION
サーバへのアクセス失敗時のリトライ回数をデフォルトで3回にします。