### PR TITLE
Do not retry at 404 response

### DIFF
--- a/libstns/request.go
+++ b/libstns/request.go
@@ -62,6 +62,10 @@ func (r *Request) GetRawData() ([]byte, error) {
 		if e == nil {
 			break
 		}
+
+		if strings.Index(e.Error(), "resource not found") > 0 {
+			return nil, e
+		}
 	}
 	return b, e
 }


### PR DESCRIPTION
404応答の場合、リトライする必要が無いのでリトライを抑制する。