### PR TITLE
systemd-resolvedからの問い合わせは無視する

### DIFF
--- a/nss/main.go
+++ b/nss/main.go
@@ -40,7 +40,7 @@ func orgInit() int {
 			return libstns.NSS_STATUS_UNAVAIL
 		}
 
-		if host.PlatformFamily == "debian" && (strings.HasSuffix(os.Args[0], "/sbin/init") || strings.HasSuffix(os.Args[0], "dbus-daemon")) {
+		if host.PlatformFamily == "debian" && (strings.HasSuffix(os.Args[0], "/sbin/init") || strings.HasSuffix(os.Args[0], "dbus-daemon") || strings.HasSuffix(os.Args[0], "systemd-resolved")) {
 			return libstns.NSS_STATUS_NOTFOUND
 		}
 


### PR DESCRIPTION
ubuntu 18の起動時にsystemd-resolvedからの問い合わせ時にNWが未起動のため、libnss-stnsがクラッシュしてその後の起動処理が停止するため、該当の問い合せは無視します。

発生時は下記のログが `/var/log/syslog` に出力される。
```
Jun 13 05:45:42 vagrant libstns[823]: 2018/06/13 05:45:42 command error:Get http://localhost:1104/v2/group/list: dial tcp [::1]:1104: getsockopt: connection refused
Jun 13 05:45:42 vagrant systemd-resolved[823]: github.com/STNS/libnss_stns/vendor/github.com/pyama86/go-cache.(*janitor).Run(0xc4200651f0, 0xc420067640)
Jun 13 05:45:42 vagrant systemd-resolved[823]: #011/go/src/github.com/STNS/libnss_stns/vendor/github.com/pyama86/go-cache/cache.go:1041 +0x173
Jun 13 05:45:42 vagrant systemd-resolved[823]: created by github.com/STNS/libnss_stns/vendor/github.com/pyama86/go-cache.runJanitor
Jun 13 05:45:42 vagrant systemd-resolved[823]: #011/go/src/github.com/STNS/libnss_stns/vendor/github.com/pyama86/go-cache/cache.go:1060 +0x8f
Jun 13 05:45:42 vagrant systemd-resolved[823]: github.com/STNS/libnss_stns/vendor/github.com/pyama86/go-cache.(*janitor).Run(0xc420065200, 0xc420067680)
Jun 13 05:45:42 vagrant systemd-resolved[823]: #011/go/src/github.com/STNS/libnss_stns/vendor/github.com/pyama86/go-cache/cache.go:1041 +0x173
Jun 13 05:45:42 vagrant systemd-resolved[823]: created by github.com/STNS/libnss_stns/vendor/github.com/pyama86/go-cache.runJanitor
Jun 13 05:45:42 vagrant systemd-resolved[823]: #011/go/src/github.com/STNS/libnss_stns/vendor/github.com/pyama86/go-cache/cache.go:1060 +0x8f
```