### PR TITLE
systemdからの問い合わせも無視する

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -12,8 +12,8 @@ import (
 	_gocache "github.com/pyama86/go-cache"
 )
 
-var attrStore = _gocache.New(time.Second*settings.CACHE_TIME, 60*time.Second)
-var lockStore = _gocache.New(time.Second*settings.LOCK_TIME, 60*time.Second)
+var attrStore = _gocache.New(time.Second*settings.CACHE_TIME, 0*time.Second)
+var lockStore = _gocache.New(time.Second*settings.LOCK_TIME, 0*time.Second)
 
 var workDir = settings.WORK_DIR
 

--- a/nss/main.go
+++ b/nss/main.go
@@ -29,6 +29,22 @@ func init() {
 	orgInit()
 }
 
+func ignoreProcess(process string) bool {
+	ignore := []string{
+		"/sbin/init",
+		"dbus-daemon",
+		"(resolved)",
+		"(systemd)",
+	}
+
+	for _, i := range ignore {
+		if strings.HasSuffix(process, i) {
+			return true
+		}
+	}
+	return false
+}
+
 func orgInit() int {
 	if pwdNss == nil || grpNss == nil || spwdNss == nil {
 		if _, err := os.FindProcess(1); err != nil {
@@ -40,10 +56,9 @@ func orgInit() int {
 			return libstns.NSS_STATUS_UNAVAIL
 		}
 
-		if host.PlatformFamily == "debian" && (strings.HasSuffix(os.Args[0], "/sbin/init") || strings.HasSuffix(os.Args[0], "dbus-daemon") || strings.HasSuffix(os.Args[0], "systemd-resolved")) {
+		if host.PlatformFamily == "debian" && ignoreProcess(os.Args[0]) {
 			return libstns.NSS_STATUS_NOTFOUND
 		}
-
 		libstns.Setlog()
 
 		config, err := libstns.LoadConfig("/etc/stns/libnss_stns.conf")


### PR DESCRIPTION
#57 に引き続き、systemdからの問い合わせにおいても無視する必要が合ったため、対応した。

```
root@vagrant:~# cat /etc/nsswitch.conf   | grep stns
passwd: compat stns systemd
group: compat stns systemd                                                     
root@vagrant:~# reboot                                                         
Connection to 127.0.0.1 closed by remote host.                 
Connection to 127.0.0.1 closed.
% vagrant ssh ubuntu                                                                                                                                   
nameserver 127.0.0.53                               
```