### PR TITLE
fix insecure permission

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -5,6 +5,8 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"os/user"
+	"strconv"
 	"time"
 
 	"github.com/STNS/STNS/stns"
@@ -72,7 +74,7 @@ func SaveResultList(resourceType string, list stns.Attributes) {
 		return
 	}
 
-	if err := os.MkdirAll(workDir, 0777); err != nil {
+	if err := os.MkdirAll(workDir, 0770); err != nil {
 		log.Println(err)
 		return
 	}
@@ -83,7 +85,10 @@ func SaveResultList(resourceType string, list stns.Attributes) {
 		return
 	}
 
-	os.Chmod(f, 0777)
+	n, _ := os.user.LookupGroup("nscd")
+	gid, _ := strconv.Atoi(n.Gid)
+	os.Chown(f, 0, gid)
+	os.Chmod(f, 0640)
 }
 
 func LastResultList(resourceType string) *stns.Attributes {


### PR DESCRIPTION
cache is owned by root and has written permissions to anyone.
nscd also needs to read cache, so I specify group.