### PR TITLE
Fix cache file's permission to erace wazuh warning

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -5,6 +5,8 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"os/user"
+	"strconv"
 	"time"
 
 	"github.com/STNS/STNS/stns"
@@ -72,7 +74,7 @@ func SaveResultList(resourceType string, list stns.Attributes) {
 		return
 	}
 
-	if err := os.MkdirAll(workDir, 0777); err != nil {
+	if err := os.MkdirAll(workDir, 0770); err != nil {
 		log.Println(err)
 		return
 	}
@@ -83,7 +85,26 @@ func SaveResultList(resourceType string, list stns.Attributes) {
 		return
 	}
 
-	os.Chmod(f, 0777)
+	n, err := user.LookupGroup("nscd")
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	gid, err := strconv.Atoi(n.Gid)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	err = os.Chown(f, 0, gid)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	err = os.Chmod(f, 0640)
+	if err != nil {
+		log.Println(err)
+		return
+	}
 }
 
 func LastResultList(resourceType string) *stns.Attributes {

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -88,17 +88,18 @@ func SaveResultList(resourceType string, list stns.Attributes) {
 	n, err := user.LookupGroup("nscd")
 	if err != nil {
 		log.Println(err)
-		return
-	}
-	gid, err := strconv.Atoi(n.Gid)
-	if err != nil {
-		log.Println(err)
-		return
-	}
-	err = os.Chown(f, 0, gid)
-	if err != nil {
-		log.Println(err)
-		return
+		log.Println("NOTICE: Skip to set owner to nscd")
+	} else {
+		gid, err := strconv.Atoi(n.Gid)
+		if err != nil {
+			log.Println(err)
+			return
+		}
+		err = os.Chown(f, 0, gid)
+		if err != nil {
+			log.Println(err)
+			return
+		}
 	}
 	err = os.Chmod(f, 0640)
 	if err != nil {

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"errors"
+	"os"
 	"testing"
 
 	"github.com/STNS/STNS/stns"
@@ -32,6 +33,26 @@ func TestWriteRead(t *testing.T) {
 	if attrs != nil || err.Error() != "test error" {
 		t.Error("rw error2")
 	}
+}
+
+func TestSaveResultList(t *testing.T) {
+	SetWorkDir("/tmp")
+
+	SaveResultList("test", stns.Attributes{"test": &stns.Attribute{
+		ID: 1,
+	}},
+	)
+
+	cachePath := "/tmp/.libnss_stns_test_cache"
+	stat, err := os.Stat(cachePath)
+
+	if err != nil {
+		t.Errorf("Got error %v", err)
+	}
+	if mode := stat.Mode(); mode != 0640 {
+		t.Errorf("Expect 0640, got %v", mode)
+	}
+
 }
 
 func TestSaveLoad(t *testing.T) {


### PR DESCRIPTION
Hi! Nice guy.

I changed cache file's permission, such as `/var/lib/libnss_stns/.libnss_stns_xxxxx_cache`, because @tnmt got some warnings while using wazuh https://wazuh.com/

```
Wazuh Notification.
2018 Jun 16 04:01:54

Received From: (admin201-integration-oreo) any->rootcheck
Rule: 510 fired (level 7) -> "Host-based anomaly detection event (rootcheck)."
Portion of the log(s):

File '/var/lib/libnss_stns/.libnss_stns_group_cache' is owned by root and has written permissions to anyone.
title: File is owned by root and has written permissions to anyone.
file: /var/lib/libnss_stns/.libnss_stns_group_cache1
```

This is a rewrite of https://github.com/STNS/libnss_stns/pull/59